### PR TITLE
feat(settings): Link to territory offline and send bug report via email

### DIFF
--- a/lib/features/settings/presentation/widgets/settings.dart
+++ b/lib/features/settings/presentation/widgets/settings.dart
@@ -25,6 +25,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_feather_icons/flutter_feather_icons.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 class Settings extends ConsumerWidget {
   const Settings({super.key});
@@ -234,7 +235,20 @@ class Settings extends ConsumerWidget {
                   dividerColor: ColorPalette.grey2Opacity20,
                   children: [
                     SectionItem(
-                      onTap: () {},
+                      onTap: () {
+                        final mailtoURI = Uri(
+                          scheme: 'mailto',
+                          path: 'info@territory-offline.com',
+                          queryParameters: {
+                            'subject': 'Bug-Report',
+                          },
+                        );
+                        try {
+                          _launchURL(mailtoURI);
+                        } catch (e) {
+                          // maybe show error alert
+                        }
+                      },
                       children: [
                         Text(
                           'settings.actions.bugReport',
@@ -248,7 +262,13 @@ class Settings extends ConsumerWidget {
                       ],
                     ),
                     SectionItem(
-                      onTap: () {},
+                      onTap: () async {
+                        final webSiteURI = Uri(
+                          scheme: 'https',
+                          host: 'territory-offline.com',
+                        );
+                        _launchURL(webSiteURI);
+                      },
                       children: [
                         Text(
                           'settings.actions.territoryOffline',
@@ -286,5 +306,13 @@ class Settings extends ConsumerWidget {
         ),
       ],
     );
+  }
+
+  Future<void> _launchURL(Uri uri) async {
+    if (await canLaunchUrl(uri)) {
+      await launchUrl(uri);
+    } else {
+      throw 'Could not launch $uri';
+    }
   }
 }

--- a/lib/features/settings/presentation/widgets/settings.dart
+++ b/lib/features/settings/presentation/widgets/settings.dart
@@ -243,11 +243,7 @@ class Settings extends ConsumerWidget {
                             'subject': 'Bug-Report',
                           },
                         );
-                        try {
-                          _launchURL(mailtoURI);
-                        } catch (e) {
-                          // maybe show error alert
-                        }
+                        _launchURL(mailtoURI);
                       },
                       children: [
                         Text(


### PR DESCRIPTION
## Description
Die WebSite wird wie in der alten version auf iOS in einem In-App-View geöffnet.
Der Bug Report öffnet die default Mail App des Users mit der email: `info@territory-offline.com`, und als Betreff: `Bug Report - Field Companion`
## Issues
* closing #35 
* closing #34

## Screenshots

<p float="left">
<img src="https://github.com/Directware/field-companion/assets/83090745/e240dc23-a692-4f9d-8156-8e66dff7571a" width="300" />
<img src="https://github.com/Directware/field-companion/assets/83090745/49353630-6b8d-42e9-919b-84c93a0883da" width="300" />
</p>